### PR TITLE
🐛 fix metaConfig

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -227,6 +227,6 @@ module.exports = {
     ...markdownPlugins,
     ...searchPlugins,
     ...pwaPlugins,
-    ...gtagPlugins,
+    // ...gtagPlugins, // Uncomment this line if you want to use Google Analytics
   ],
 }

--- a/gatsby-meta-config.js
+++ b/gatsby-meta-config.js
@@ -18,14 +18,14 @@
 /** @type {MetaConfig} */
 const metaConfig = {
   //TODO: Change the values below according to your project
-  title: "",
-  description: "",
-  author: "",
-  siteUrl: "",
-  lang: "",
-  utterances: "",
-  links: {},
-  favicon: "",
+  title: "tmp-title",
+  description: "tmp-description",
+  author: "tmp-author",
+  siteUrl: "https://tmp-siteUrl.netlify.app",
+  lang: "ko-KR",
+  utterances: "tmp-utterances",
+  links: { github: "https://github.com/mingi3314/blog-stream" },
+  favicon: "src/images/icon.png",
 }
 
 // eslint-disable-next-line no-undef


### PR DESCRIPTION
- Commented out `gtagPlugins` in `gatsby-config.js` to provide instructions for enabling Google Analytics.
- Updated `gatsby-meta-config.js` with temporary meta configuration values such as title, description, author, siteUrl, lang, utterances, and links.

---

