### PR TITLE
🔧 add links

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -19,10 +19,14 @@ const siteMetadata = {
     //   link: "/about/",
     //   name: "About",
     // },
-    // {
-    //   link: meta.links.github,
-    //   name: "Github",
-    // },
+    {
+      link: meta.links.github,
+      name: "Github",
+    },
+    {
+      link: meta.links.juiceTarget,
+      name: "See Also",
+    },
   ],
 }
 

--- a/gatsby-meta-config.js
+++ b/gatsby-meta-config.js
@@ -1,6 +1,7 @@
 /**
  * @typedef {Object} Links
  * @prop {string} github Your github repository
+ * @prop {string} juiceTarget Your target URL
  */
 
 /**
@@ -24,7 +25,10 @@ const metaConfig = {
   siteUrl: "https://blog-stream.netlify.app",
   lang: "en-US",
   utterances: "mingi3314/blog-stream",
-  links: { github: "https://github.com/mingi3314/blog-stream" },
+  links: {
+    github: "https://github.com/mingi3314/blog-stream",
+    juiceTarget: "https://alphasquare.co.kr/",
+  },
   favicon: "src/images/icon.png",
 }
 

--- a/src/components/navBar/navBar.tsx
+++ b/src/components/navBar/navBar.tsx
@@ -24,7 +24,6 @@ interface NavBarProperties {
 
 const NavBar: React.FC<NavBarProperties> = ({ title, themeToggler }) => {
   const { menuLinks } = useSiteMetadata()
-  console.log(menuLinks)
   const { device } = useContext(ThemeContext)!
   const navReference = useRef<HTMLElement>(null)
   const curtainReference = useRef<HTMLDivElement>(null)

--- a/src/components/navBar/navBar.tsx
+++ b/src/components/navBar/navBar.tsx
@@ -24,6 +24,7 @@ interface NavBarProperties {
 
 const NavBar: React.FC<NavBarProperties> = ({ title, themeToggler }) => {
   const { menuLinks } = useSiteMetadata()
+  console.log(menuLinks)
   const { device } = useContext(ThemeContext)!
   const navReference = useRef<HTMLElement>(null)
   const curtainReference = useRef<HTMLDivElement>(null)


### PR DESCRIPTION
Updated `gatsby-config.js` and `gatsby-meta-config.js` to add 'See Also' link beside GitHub link in navbar. This addition required updating the `meta` object to include a new property `juiceTarget`. A debug statement `console.log(menuLinks)` has also been added in `navBar.tsx`.

---

