### PR TITLE
👷 add auto upload content action

### DIFF
--- a/.github/workflows/auto-upload-contents.yaml
+++ b/.github/workflows/auto-upload-contents.yaml
@@ -1,0 +1,46 @@
+name: Auto Upload Contents
+
+on:
+  workflow_dispatch:
+    inputs:
+      n_content:
+        description: "Number of content pieces to generate"
+        required: true
+        default: "1"
+      topic:
+        description: "Topic for content generation"
+        required: true
+        default: "Free Topic"
+      enable_langchain_tracing:
+        description: "Enable LangChain tracing (true/false)"
+        required: false
+        default: "false"
+
+jobs:
+  generate-content:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: "18"
+
+      - name: Install dependencies
+        run: yarn install
+
+      - name: Generate content
+        run: yarn generate-content --n-content ${{ github.event.inputs.n_content }} --topic "${{ github.event.inputs.topic }}"
+        env:
+          MISTRAL_API_KEY: ${{ secrets.MISTRAL_API_KEY }}
+          LANGCHAIN_TRACING_V2: ${{ github.event.inputs.enable_langchain_tracing }}
+          LANGCHAIN_API_KEY: ${{ secrets.LANGCHAIN_API_KEY }}
+
+      - name: Commit and push if changes
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git add -A
+          git diff --quiet && git diff --staged --quiet || (git commit -m "Add generated content for ${{ github.event.inputs.topic }}" && git push)


### PR DESCRIPTION
This pull request introduces a new GitHub Action workflow, `auto-upload-contents.yaml`. The workflow is configured to trigger manually (`workflow_dispatch`) and supports parameters such as `n_content`, `topic`, and `enable_langchain_tracing`. It automates the process of content generation and subsequent upload to the repository.

### What changed?

- A new workflow file `.github/workflows/auto-upload-contents.yaml` was added.
- The workflow includes steps to checkout code, set up Node.js, install dependencies, generate content using Node.js, and commit and push changes if any content is generated.

### How to test?

1. Trigger the workflow manually from the GitHub Actions tab.
2. Specify the number of content pieces to generate (`n_content`) and the topic (`topic`). Optionally, enable LangChain tracing by setting `enable_langchain_tracing` to `true`.
3. Verify that the generated content is committed and pushed to the repository.

### Why make this change?

This change automates the content generation process, thereby saving time and ensuring consistency across generated content. It leverages GitHub Actions to streamline the workflow and reduces manual intervention.

---

